### PR TITLE
Add circular-dependency-plugin

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -17,6 +17,7 @@ const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
 const WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin');
 const eslintFormatter = require('react-dev-utils/eslintFormatter');
 const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
+const CircularDependencyPlugin = require('circular-dependency-plugin');
 const getClientEnvironment = require('./env');
 const paths = require('./paths');
 
@@ -284,6 +285,15 @@ module.exports = {
     // https://github.com/jmblog/how-to-optimize-momentjs-with-webpack
     // You can remove this if you don't use Moment.js:
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+    // Detect modules with circular dependencies when bundling with webpack.
+    new CircularDependencyPlugin({
+      // exclude detection of files in node_modules
+      exclude: /node_modules/,
+      // add errors to webpack instead of warnings
+      failOnError: true,
+      // set the current working directory for displaying module paths
+      cwd: process.cwd(),
+    }),
   ],
   // Some libraries import Node modules but don't use them in the browser.
   // Tell Webpack to provide empty mocks for them so importing them works.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -32,6 +32,7 @@
     "babel-runtime": "6.26.0",
     "case-sensitive-paths-webpack-plugin": "2.1.1",
     "chalk": "1.1.3",
+    "circular-dependency-plugin": "4.4.0",
     "css-loader": "0.28.7",
     "dotenv": "4.0.0",
     "dotenv-expand": "4.2.0",


### PR DESCRIPTION
This PR is to add circular-dependency-plugin. Now when we start the server, it will fail if there is any circular dependency detected. 

Adding this plugin does not slow down the starting process, so it's better if we check it on local machine and make sure it works before pushing code to CI.

![screen shot 2018-03-21 at 2 59 48 pm 2](https://user-images.githubusercontent.com/4929170/37699119-8867d114-2d18-11e8-9ff4-4c990b6fb224.png)
